### PR TITLE
Speed improvements

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -87,6 +87,18 @@ func execChangeContains(rootDir, from, to string) error {
 	return nil
 }
 
+func countUpperCase(str string) int {
+	uppers := 0
+
+	for i, v := range str {
+		if i > 0 && unicode.IsUpper(v) {
+			uppers++
+		}
+	}
+
+	return uppers
+}
+
 func execSnakeCase(rootDir string) error {
 	var wg sync.WaitGroup
 
@@ -102,13 +114,8 @@ func execSnakeCase(rootDir string) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			uppers := 0
 			relativeName := info.Name()
-			for i, v := range relativeName {
-				if i > 0 && unicode.IsUpper(v) {
-					uppers++
-				}
-			}
+			uppers := countUpperCase(relativeName)
 			res := make([]byte, len(filename)+uppers)
 			copy(res, filename[0:len(filename)-len(relativeName)])
 			ptr := len(filename) - len(relativeName)
@@ -116,6 +123,7 @@ func execSnakeCase(rootDir string) error {
 				if unicode.IsSpace(v) {
 					res[ptr] = '_'
 					ptr++
+
 					continue
 				}
 
@@ -146,6 +154,18 @@ func execSnakeCase(rootDir string) error {
 	return nil
 }
 
+func countCamelCaseSeps(str string) int {
+	separators := 0
+
+	for _, v := range str {
+		if v == '_' || v == '-' || unicode.IsSpace(v) {
+			separators++
+		}
+	}
+
+	return separators
+}
+
 func execCamelCase(rootDir string) error {
 	var wg sync.WaitGroup
 
@@ -163,13 +183,8 @@ func execCamelCase(rootDir string) error {
 			defer wg.Done()
 			forceUpperNext := false
 
-			removed := 0
 			relativeName := info.Name()
-			for _, v := range relativeName {
-				if v == '_' || v == '-' || unicode.IsSpace(v) {
-					removed++
-				}
-			}
+			removed := countCamelCaseSeps(relativeName)
 
 			res := make([]byte, len(fileName)-removed)
 			ptr := len(fileName) - len(relativeName)
@@ -180,12 +195,14 @@ func execCamelCase(rootDir string) error {
 					res[ptr] = byte(unicode.ToUpper(v))
 					ptr++
 					forceUpperNext = false
+
 					continue
 				}
 
 				if i == 0 {
 					res[ptr] = byte(unicode.ToLower(v))
 					ptr++
+
 					continue
 				}
 

--- a/replacer.go
+++ b/replacer.go
@@ -20,7 +20,7 @@ func execChangeExtension(rootDir, from, to string) error {
 
 	var wg sync.WaitGroup
 
-	err := filepath.Walk(rootDir, func(filename string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootDir, func(filename string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func execChangeExtension(rootDir, from, to string) error {
 func execChangeContains(rootDir, from, to string) error {
 	var wg sync.WaitGroup
 
-	err := filepath.Walk(rootDir, func(filename string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootDir, func(filename string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func execChangeContains(rootDir, from, to string) error {
 func execSnakeCase(rootDir string) error {
 	var wg sync.WaitGroup
 
-	err := filepath.Walk(rootDir, func(filename string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootDir, func(filename string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func execSnakeCase(rootDir string) error {
 func execCamelCase(rootDir string) error {
 	var wg sync.WaitGroup
 
-	err := filepath.Walk(rootDir, func(fileName string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootDir, func(fileName string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Switch to filepath.WalkDir from filepath.Walk - from filepath.Walk doc `Walk is less efficient than WalkDir, introduced in Go 1.16, which avoids calling os.Lstat on every visited file or directory.`

Rewrite some of the "translation" logic as well so that it should be faster and more memory efficient - benchmarks as I was writing it showed speed improvements by a couple of times (for the generating the new name only) and less memory allocations. I've not updated the benchmarks in the README.md file however as I'm working on quite a different system with different performance so it wouldn't really be comparable.